### PR TITLE
Use protocol-relative URIs

### DIFF
--- a/themes/lgm2016/css/dev/20-general.css
+++ b/themes/lgm2016/css/dev/20-general.css
@@ -18,7 +18,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#12a16d', end
 }
 
 html {
-	background-image: url('http://libregraphicsmeeting.org/2016/wp/wp-content/design/website/background/GIMP-glitch-background-v3.jpg');
+	background-image: url('//libregraphicsmeeting.org/2016/wp/wp-content/design/website/background/GIMP-glitch-background-v3.jpg');
 	background-size: 100% auto;
 }
 
@@ -26,7 +26,7 @@ body {
 /*	background: none;
 	background-size: cover;*/
 
-	background-image: url('http://libregraphicsmeeting.org/2016/wp/wp-content/design/website/background/GIMP-glitch-background-v2.jpg');
+	background-image: url('//libregraphicsmeeting.org/2016/wp/wp-content/design/website/background/GIMP-glitch-background-v2.jpg');
 	background-size: 100% auto;
 	background-attachment: fixed;
 }
@@ -59,7 +59,7 @@ a {
 .site-banner {
 	background-color: transparent;
 	padding-top: 300px;
-	background-image: url('http://libregraphicsmeeting.org/2016/wp/wp-content/design/website/banner/Webbanner.png');
+	background-image: url('//libregraphicsmeeting.org/2016/wp/wp-content/design/website/banner/Webbanner.png');
 	background-size: 100% auto;
 	padding-top: 28%;
 }


### PR DESCRIPTION
Use protocol-relative URIs to avoid browser security warnings. This fixes only those in code. There seem to be some more in the database? http://pastebin.com/r5E46jx2 is a list of those, Firefox complained about **while visiting** the `/register` page.

![lgm security warning](https://cloud.githubusercontent.com/assets/2311611/13828714/41719792-ebc3-11e5-9e26-2faae0e427ea.png)
